### PR TITLE
Fix React PropTypes warnings

### DIFF
--- a/__tests__/TagCloud-test.js
+++ b/__tests__/TagCloud-test.js
@@ -6,7 +6,7 @@ jest.mock('array-shuffle', () => arr => arr.slice().reverse());
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import { TagCloud } from '../src/TagCloud';
 
 const { createSpy, any } = jasmine;

--- a/__tests__/defaultRenderer-test.js
+++ b/__tests__/defaultRenderer-test.js
@@ -3,7 +3,7 @@ jest.unmock('../src/helpers');
 
 jest.mock('randomcolor', () => o => Object.keys(o).length ? 'custom' : 'red');
 
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import { defaultRenderer } from '../src/defaultRenderer';
 
 const { any, objectContaining } = jasmine;

--- a/lib/TagCloud.js
+++ b/lib/TagCloud.js
@@ -11,6 +11,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _defaultRenderer = require('./defaultRenderer');
 
 var _arrayShuffle = require('array-shuffle');
@@ -134,14 +138,14 @@ var TagCloud = exports.TagCloud = function (_React$Component) {
 }(_react2.default.Component);
 
 TagCloud.propTypes = {
-  tags: _react2.default.PropTypes.array.isRequired,
-  maxSize: _react2.default.PropTypes.number.isRequired,
-  minSize: _react2.default.PropTypes.number.isRequired,
-  shuffle: _react2.default.PropTypes.bool,
-  colorOptions: _react2.default.PropTypes.object,
-  disableRandomColor: _react2.default.PropTypes.bool,
-  renderer: _react2.default.PropTypes.func,
-  className: _react2.default.PropTypes.string
+  tags: _propTypes2.default.array.isRequired,
+  maxSize: _propTypes2.default.number.isRequired,
+  minSize: _propTypes2.default.number.isRequired,
+  shuffle: _propTypes2.default.bool,
+  colorOptions: _propTypes2.default.object,
+  disableRandomColor: _propTypes2.default.bool,
+  renderer: _propTypes2.default.func,
+  className: _propTypes2.default.string
 };
 
 TagCloud.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tagcloud",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Tag/word cloud component for react",
   "main": "lib/index.js",
   "scripts": {
@@ -31,6 +31,7 @@
   "dependencies": {
     "array-shuffle": "^1.0.0",
     "object-assign": "^4.1.0",
+    "prop-types": "^15.5.8",
     "randomcolor": "^0.4.2"
   },
   "devDependencies": {
@@ -44,7 +45,6 @@
     "eslint": "^3.2.2",
     "eslint-plugin-react": "^6.0.0",
     "jest-cli": "^17.0.0",
-    "prop-types": "^15.5.8",
     "react": "^15.0.2",
     "react-addons-test-utils": "^15.0.2",
     "react-dom": "^15.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tagcloud",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Tag/word cloud component for react",
   "main": "lib/index.js",
   "scripts": {
@@ -44,6 +44,7 @@
     "eslint": "^3.2.2",
     "eslint-plugin-react": "^6.0.0",
     "jest-cli": "^17.0.0",
+    "prop-types": "^15.5.8",
     "react": "^15.0.2",
     "react-addons-test-utils": "^15.0.2",
     "react-dom": "^15.0.2",

--- a/src/TagCloud.js
+++ b/src/TagCloud.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { defaultRenderer } from './defaultRenderer';
 import arrayShuffle from 'array-shuffle';
 import randomColor from 'randomcolor';
@@ -73,14 +74,14 @@ export class TagCloud extends React.Component {
 }
 
 TagCloud.propTypes = {
-  tags: React.PropTypes.array.isRequired,
-  maxSize: React.PropTypes.number.isRequired,
-  minSize: React.PropTypes.number.isRequired,
-  shuffle: React.PropTypes.bool,
-  colorOptions: React.PropTypes.object,
-  disableRandomColor: React.PropTypes.bool,
-  renderer: React.PropTypes.func,
-  className: React.PropTypes.string
+  tags: PropTypes.array.isRequired,
+  maxSize: PropTypes.number.isRequired,
+  minSize: PropTypes.number.isRequired,
+  shuffle: PropTypes.bool,
+  colorOptions: PropTypes.object,
+  disableRandomColor: PropTypes.bool,
+  renderer: PropTypes.func,
+  className: PropTypes.string
 };
 
 TagCloud.defaultProps = {


### PR DESCRIPTION
* Fix React PropTypes warnings
* Import React TestUtils from 'react-dom/test-utils' to fix deprecation warnings from tests
* Recompile and bump version