### PR TITLE
Added Title attribute in span tag

### DIFF
--- a/src/defaultRenderer.js
+++ b/src/defaultRenderer.js
@@ -5,7 +5,7 @@ export const defaultRenderer = (tag, size, color) => {
   const key = tag.key || tag.value
   const style = { ...styles, color, fontSize }
   return (
-    <span className="tag-cloud-tag" style={style} key={key}>
+    <span className="tag-cloud-tag" style={style} key={key} title={`${tag.value} :${tag.count}`}>
       {tag.value}
     </span>
   )


### PR DESCRIPTION
Currently on hovering tag it does not shows value & count.
It would be great if these details added into defaultRenderer itself.
Using the title attribute in span, we can display the browser's default tooltips on supported browsers.