### PR TITLE
Offer Render Additional Props

### DIFF
--- a/lib/TagCloud.js
+++ b/lib/TagCloud.js
@@ -55,7 +55,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 var handlersPropNames = ['onClick', 'onDoubleClick', 'onMouseMove', 'onMouseOver', 'onMouseOut', // rn handlers
 'onPress', 'onPressIn', 'onPressOut'];
-var cloudPropNames = ['tags', 'shuffle', 'renderer', 'maxSize', 'minSize', 'colorOptions', 'disableRandomColor', 'randomSeed', 'randomNumberGenerator', 'containerComponent'];
+var cloudPropNames = ['tags', 'shuffle', 'renderer', 'rendererProps', 'maxSize', 'minSize', 'colorOptions', 'disableRandomColor', 'randomSeed', 'randomNumberGenerator', 'containerComponent'];
 
 function getTagHashCode(tag) {
   return tag.key + tag.value + tag.count;
@@ -96,7 +96,8 @@ function withTagCloudHandlers(elem, tag, cloudHandlers) {
 
 function renderTags(props, data) {
   var minSize = props.minSize,
-      maxSize = props.maxSize;
+      maxSize = props.maxSize,
+      rendererProps = props.rendererProps;
   var counts = data.map(function (_ref2) {
     var tag = _ref2.tag;
     return tag.count;
@@ -108,7 +109,7 @@ function renderTags(props, data) {
     var tag = _ref3.tag,
         color = _ref3.color;
     var fontSize = (0, _helpers.fontSizeConverter)(tag.count, min, max, minSize, maxSize);
-    var elem = props.renderer(tag, fontSize, color);
+    var elem = props.renderer(tag, fontSize, color, rendererProps);
     return withTagCloudHandlers(elem, tag, cloudHandlers);
   });
 }
@@ -155,6 +156,7 @@ TagCloud.propTypes = {
   colorOptions: _propTypes["default"].object,
   disableRandomColor: _propTypes["default"].bool,
   renderer: _propTypes["default"].func,
+  rendererProps: _propTypes["default"].object,
   className: _propTypes["default"].string,
   randomSeed: _propTypes["default"].any,
   randomNumberGenerator: _propTypes["default"].func,

--- a/src/TagCloud.js
+++ b/src/TagCloud.js
@@ -22,6 +22,7 @@ const cloudPropNames = [
   'tags',
   'shuffle',
   'renderer',
+  'rendererProps',
   'maxSize',
   'minSize',
   'colorOptions',
@@ -63,14 +64,14 @@ function withTagCloudHandlers(elem, tag, cloudHandlers) {
 }
 
 function renderTags(props, data) {
-  const { minSize, maxSize } = props
+  const { minSize, maxSize, rendererProps } = props
   const counts = data.map(({ tag }) => tag.count),
     min = Math.min(...counts),
     max = Math.max(...counts)
   const cloudHandlers = pick(props, handlersPropNames)
   return data.map(({ tag, color }) => {
     const fontSize = fontSizeConverter(tag.count, min, max, minSize, maxSize)
-    const elem = props.renderer(tag, fontSize, color)
+    const elem = props.renderer(tag, fontSize, color, rendererProps)
     return withTagCloudHandlers(elem, tag, cloudHandlers)
   })
 }
@@ -112,6 +113,7 @@ TagCloud.propTypes = {
   colorOptions: PropTypes.object,
   disableRandomColor: PropTypes.bool,
   renderer: PropTypes.func,
+  rendererProps: PropTypes.object,
   className: PropTypes.string,
   randomSeed: PropTypes.any,
   randomNumberGenerator: PropTypes.func,


### PR DESCRIPTION
Tags are allowed to have props associated with them. However, changes to the tags are not reflected due to shallow compare. This PR creates possibility for someone to pass props to custom renderer directly instead of having to pass props to each individual tag.